### PR TITLE
docs: rewrite README to lead with swarm workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Agentic Framework
 
-Specialized personas and reusable workflows for Claude Code.
+Parallel agent swarms for Claude Code. Ship features faster with coordinated multi-agent workflows.
 
 ## Install
 
@@ -11,75 +11,101 @@ curl -sSL https://raw.githubusercontent.com/dralgorhythm/claude-agentic-framewor
 
 Then start Claude Code: `claude`
 
-## Try It
+## The Swarm Workflow
 
-```
-/builder fix the login bug
-```
+The fastest way to go from idea to shipped code. One agent thinks, then many agents build.
 
-That's it. Claude adopts the Builder persona and works on your task.
+### 1. Research — Single agent, deep thinking
 
-## Example: Feature from Idea to Code
+Use a persona to explore the problem space and draft your planning prompt:
 
 ```
 /product-manager user notifications
+/architect redesign the auth system
 ```
-Claude writes a PR-FAQ and PRD in `artifacts/`.
+
+This produces artifacts (PR-FAQs, PRDs, ADRs) that feed the next step.
+
+### 2. Plan — Parallel exploration
 
 ```
-/architect
+/swarm-plan implement user notifications per the PRD
 ```
-Claude reads the PRD, designs the system, writes an ADR.
+
+Launches 3-6 explorer agents in parallel. They research existing patterns, dependencies, and constraints simultaneously, then produce a decomposed plan tracked as Beads.
+
+### 3. Execute — Parallel implementation
 
 ```
-/builder
+/swarm-execute
 ```
-Claude implements it with tests.
+
+Picks up the planned work and fans out across multiple builder agents. Each worker claims a task, implements it, runs quality gates (tests, lint, types, build), and pushes to remote. Up to 8 workers in parallel.
+
+### 4. Review — Adversarial, multi-pass
 
 ```
-/reviewer
+/swarm-review    # run 2-3 times
 ```
-Claude reviews for bugs and security issues.
 
-Each step builds on the previous. Artifacts pass between personas automatically.
+Each pass launches 5 parallel reviewers covering different perspectives: security (OWASP Top 10), performance, architecture, test coverage, and code quality. Repeat until clean. Then ship the PR.
 
-## What You Get
+### Full cycle
 
-**9 Personas** — Switch expertise with slash commands
+```
+/product-manager <feature>  →  /swarm-plan  →  /swarm-execute  →  /swarm-review (2-3x)  →  PR
+```
+
+## Swarm Workers
+
+Eight specialized agent types, each tuned for cost and capability:
+
+| Worker | Model | Use |
+|--------|-------|-----|
+| `worker-explorer` | Haiku | Fast codebase search |
+| `worker-builder` | Sonnet | Implementation |
+| `worker-reviewer` | Sonnet | Code review |
+| `worker-tester` | Sonnet | Test writing |
+| `worker-researcher` | Sonnet | Web research |
+| `worker-architect` | Opus | Complex design decisions |
+| `worker-security` | Sonnet | Security analysis |
+| `worker-refactor` | Sonnet | Code cleanup |
+
+Haiku for read-only exploration. Sonnet for most work. Opus only for hard architectural calls.
+
+## Personas
+
+For single-agent work, ideation, and research:
+
 ```
 /architect       /builder          /product-manager
 /reviewer        /qa-engineer      /refactoring-engineer
 /sre             /security-auditor /ui-ux-designer
 ```
 
-**4 Swarm Commands** — Orchestrate parallel agents
-```
-/swarm-plan      /swarm-execute    /swarm-review    /code-check
-```
+Personas produce artifacts in `artifacts/` that chain naturally into swarm workflows.
 
-**65+ Skills** — Auto-suggested based on what you ask
-```
-designing-systems, debugging, react-patterns, data-to-ui, ...
-```
+## Also Included
 
-**Swarm Workers** — Parallel agents for big jobs
-
-**MCP Servers** — Browser debugging, GitHub integration, structured reasoning, library docs
+- **65+ Skills** — Auto-suggested based on context (designing-systems, debugging, react-patterns, ...)
+- **Beads** — Lightweight issue tracking that coordinates swarm workers via git
+- **MCP Servers** — Browser debugging, GitHub integration, structured reasoning, library docs
+- **`/code-check`** — Holistic codebase audit for SOLID, DRY, consistency
 
 ## After Install
 
 1. Open `CLAUDE.md` and add your build/test commands
-2. Check `artifacts/` after using personas — that's where docs land
-3. **Required**: Edit `.claude/rules/tech-strategy.md` to match your tech stack
+2. **Required**: Edit `.claude/rules/tech-strategy.md` to match your tech stack
+3. Try the swarm workflow on your next feature
 
 ## Docs
 
 - [Installation details](docs/getting-started.md)
-- [MCP servers](docs/mcp-servers.md)
+- [Multi-agent swarms](docs/swarm.md)
 - [All personas](docs/personas.md)
 - [Skills reference](docs/skills.md)
-- [Multi-agent swarms](docs/swarm.md)
+- [Beads issue tracking](docs/beads.md)
+- [MCP servers](docs/mcp-servers.md)
 - [Customization](docs/customization.md)
 - [Hooks](docs/hooks.md)
 - [Handoffs](docs/handoffs.md)
-- [Beads issue tracking](docs/beads.md)

--- a/templates/agent.template.md
+++ b/templates/agent.template.md
@@ -1,1 +1,0 @@
-claude_mechanisms/agent.template.md

--- a/templates/command.template.md
+++ b/templates/command.template.md
@@ -1,1 +1,0 @@
-claude_mechanisms/command.template.md

--- a/templates/hook.template.sh
+++ b/templates/hook.template.sh
@@ -1,1 +1,0 @@
-claude_mechanisms/hook.template.sh

--- a/templates/rule.template.md
+++ b/templates/rule.template.md
@@ -1,1 +1,0 @@
-claude_mechanisms/rule.template.md

--- a/templates/skill.template.md
+++ b/templates/skill.template.md
@@ -1,1 +1,0 @@
-claude_mechanisms/skill.template.md


### PR DESCRIPTION
## Summary

- Restructures README to position parallel agent swarms as the core value proposition
- Adds a clear 4-step swarm workflow section: Research (single agent) → `/swarm-plan` → `/swarm-execute` → `/swarm-review` (2-3x)
- Promotes the swarm workers table to a top-level section with model-selection rationale
- Repositions personas as the single-agent ideation/research phase that feeds into swarms
- Removes broken template symlinks pointing to `claude_mechanisms/`

## Test plan

- [ ] Verify all markdown renders correctly on GitHub
- [ ] Confirm doc links still resolve
- [ ] Review that the swarm workflow narrative is clear for new users

🤖 Generated with [Claude Code](https://claude.com/claude-code)