### PR TITLE
PR1: Worker model tiering + least-privilege tools

### DIFF
--- a/.claude/agents/worker-architect.md
+++ b/.claude/agents/worker-architect.md
@@ -3,6 +3,7 @@ name: worker-architect
 description: Senior architecture decisions. Use for complex design problems requiring deep analysis.
 permissionMode: acceptEdits
 model: opus
+tools: Read, Grep, Glob, Write
 skills: designing-systems, writing-adrs, designing-apis
 ---
 

--- a/.claude/agents/worker-builder.md
+++ b/.claude/agents/worker-builder.md
@@ -3,6 +3,7 @@ name: worker-builder
 description: Implementation, testing, and refactoring worker for swarm tasks. Use for parallel coding, test writing, and code cleanup.
 permissionMode: acceptEdits
 model: sonnet
+tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 
 # Builder Worker

--- a/.claude/agents/worker-explorer.md
+++ b/.claude/agents/worker-explorer.md
@@ -3,6 +3,7 @@ name: worker-explorer
 description: Codebase exploration and web research worker. Use for pattern search, dependency mapping, doc lookup, and library comparison.
 permissionMode: default
 model: haiku
+tools: Read, Grep, Glob, WebFetch, WebSearch
 ---
 
 # Explorer Worker

--- a/.claude/agents/worker-research.md
+++ b/.claude/agents/worker-research.md
@@ -1,5 +1,6 @@
 ---
-model: opus
+model: sonnet
+tools: Read, Grep, Glob, WebFetch, WebSearch, Write
 name: worker-research
 description: "Deep research and investigation worker. Use for multi-source analysis, technology evaluation, competitive research, and comprehensive documentation."
 permissionMode: acceptEdits

--- a/.claude/agents/worker-researcher.md
+++ b/.claude/agents/worker-researcher.md
@@ -3,6 +3,7 @@ name: worker-researcher
 description: Quick web research and documentation lookup. Use for API docs, library comparison, and best practices.
 permissionMode: acceptEdits
 model: sonnet
+tools: Read, Grep, Glob, WebFetch, WebSearch
 ---
 
 # Researcher Worker

--- a/.claude/agents/worker-reviewer.md
+++ b/.claude/agents/worker-reviewer.md
@@ -2,7 +2,8 @@
 name: worker-reviewer
 description: Code review, security audit, and QA worker for swarm tasks. Use for parallel review, vulnerability detection, and quality assessment.
 permissionMode: acceptEdits
-model: opus
+model: sonnet
+tools: Read, Grep, Glob, Bash
 skills: application-security
 ---
 

--- a/.claude/commands/swarm-execute.md
+++ b/.claude/commands/swarm-execute.md
@@ -39,14 +39,16 @@ Execute plans using parallel worker swarms with quality gates and Beads tracking
 
 ## Worker Types
 
-| Worker | Model | Primary Use |
-|--------|-------|-------------|
-| `worker-explorer` | haiku | Fast codebase search, web research, dependency mapping |
-| `worker-builder` | sonnet | Implementation, testing, refactoring |
-| `worker-reviewer` | opus | Code review, security audit, quality assessment |
-| `worker-researcher` | sonnet | Quick web research, API docs, library comparison |
-| `worker-research` | opus | Deep multi-source investigation, technology evaluation |
-| `worker-architect` | opus | Complex design decisions, ADRs, system architecture |
+| Worker | Primary Use |
+|--------|-------------|
+| `worker-explorer` | Fast codebase search, web research, dependency mapping |
+| `worker-builder` | Implementation, testing, refactoring |
+| `worker-reviewer` | Code review, security audit, quality assessment |
+| `worker-researcher` | Quick web research, API docs, library comparison |
+| `worker-research` | Deep multi-source investigation, technology evaluation |
+| `worker-architect` | Complex design decisions, ADRs, system architecture |
+
+Model tiers are pinned in each agent's frontmatter (`.claude/agents/`) — that is the single source of truth.
 
 ## Worker Focus Modes
 

--- a/.claude/commands/swarm-plan.md
+++ b/.claude/commands/swarm-plan.md
@@ -51,14 +51,16 @@ Decompose features into actionable plans using parallel exploration swarms.
 
 ## Worker Types
 
-| Worker | Model | Primary Use |
-|--------|-------|-------------|
-| `worker-explorer` | haiku | Fast codebase search, web research, dependency mapping |
-| `worker-builder` | sonnet | Implementation, testing, refactoring |
-| `worker-reviewer` | opus | Code review, security audit, quality assessment |
-| `worker-researcher` | sonnet | Quick web research, API docs, library comparison |
-| `worker-research` | opus | Deep multi-source investigation, technology evaluation |
-| `worker-architect` | opus | Complex design decisions, ADRs, system architecture |
+| Worker | Primary Use |
+|--------|-------------|
+| `worker-explorer` | Fast codebase search, web research, dependency mapping |
+| `worker-builder` | Implementation, testing, refactoring |
+| `worker-reviewer` | Code review, security audit, quality assessment |
+| `worker-researcher` | Quick web research, API docs, library comparison |
+| `worker-research` | Deep multi-source investigation, technology evaluation |
+| `worker-architect` | Complex design decisions, ADRs, system architecture |
+
+Model tiers are pinned in each agent's frontmatter (`.claude/agents/`) — that is the single source of truth.
 
 ## Swarm Patterns
 

--- a/.claude/commands/swarm-research.md
+++ b/.claude/commands/swarm-research.md
@@ -25,11 +25,13 @@ Coordinate parallel research workers to investigate topics deeply and synthesize
 
 ## Worker Dispatch
 
-| Task Type | Worker | Model | Max Concurrent |
-|-----------|--------|-------|----------------|
-| Deep research | worker-research | opus | Up to 8 |
-| Quick fact-check | worker-explorer | haiku | Up to 8 |
-| Architecture/design research | worker-architect | opus | 1-2 |
+| Task Type | Worker | Max Concurrent |
+|-----------|--------|----------------|
+| Deep research | worker-research | Up to 8 |
+| Quick fact-check | worker-explorer | Up to 8 |
+| Architecture/design research | worker-architect | 1-2 |
+
+Model tiers are pinned in each agent's frontmatter (`.claude/agents/`) — that is the single source of truth.
 
 **Rules**:
 - Each worker gets exactly one topic or sub-topic — never overload a single worker
@@ -128,7 +130,7 @@ bd close <id> --reason="Research complete, output at [path]"
 - Flag topics where the orchestrator's own judgment fills gaps (distinguish from sourced findings)
 - Prefer dispatching a follow-up worker over guessing to fill a gap
 - Respect the max concurrent worker limit (8)
-- Use opus model for research workers — they need maximum reasoning depth
+- Worker model tiers are pinned in agent frontmatter; do not override them per-dispatch
 
 ## Error Handling
 

--- a/.claude/rules/agent-constraints.md
+++ b/.claude/rules/agent-constraints.md
@@ -4,9 +4,9 @@ Rules that apply to all agent workflows.
 
 ## Anti-Patterns
 
-- NO loading full context into workers
-- NO sharing state between workers (use Beads)
-- NO workers spawning workers (single-level only)
-- NO long-running workers (timeout at 5 min)
-- NO opus for simple tasks (cost optimization)
-- NO skipping git push (work is NOT complete until pushed)
+- NO loading full context into workers — give each worker a focused, self-contained prompt
+- NO sharing mutable state between workers — the orchestrator owns coordination and task tracking
+- NO workers spawning workers — a deliberate cost/complexity policy, enforced by omitting `Agent` from every worker's `tools` allowlist (the platform itself allows nesting up to depth 5)
+- NO unbounded workers — bound runtime with `maxTurns` in agent frontmatter rather than wall-clock limits
+- NO premium models for mechanical tasks — model tiering is pinned in each agent's frontmatter, which is the single source of truth for model assignments
+- NO skipping git push — work is NOT complete until pushed


### PR DESCRIPTION
Implements **PR1** of the modernization plan (`artifacts/plan_claude_config_modernization.md`, stacked on #8).

## Changes
- **Model tiering**: `worker-research` and `worker-reviewer` downgraded opus → sonnet. Final tiering: architect=opus, everything else sonnet (explorer=haiku). Matches the validated orchestrator-premium / workers-efficient pattern.
- **Least-privilege tools**: every worker now declares an explicit `tools:` allowlist (readers get no Write/Edit; only builder can edit; `worker-research` gets Write for its scratchpad report protocol). No worker lists `Agent` → single-level nesting enforced by omission.
- **agent-constraints.md**: nesting reframed as deliberate policy (platform allows depth 5); wall-clock limit replaced with `maxTurns` guidance; model-tiering anchored to frontmatter as single source of truth.
- **Drift fix**: swarm command docs no longer hardcode worker models (Model columns removed; frontmatter is authoritative).

## Acceptance criteria (verified)
- `grep "^model:" .claude/agents/*.md` → only architect on opus, aliases only ✅
- All 6 agents have explicit `tools:`; none lists `Agent` ✅
- `git grep -E 'worker-(reviewer|research).*opus'` (excl. artifacts) → 0 ✅
- Adversarial verify agent: PASS; invariants gate: ALL GREEN ✅

Stack: #8 ← **this** ← PR2…

🤖 Generated with [Claude Code](https://claude.com/claude-code)