### PR TITLE
PR6: Hooks hardening + permission-layer secret enforcement

### DIFF
--- a/.claude/hooks/branch-pr-discipline.sh
+++ b/.claude/hooks/branch-pr-discipline.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# branch-pr-discipline.sh
+#
+# Purpose:
+#   Warn (never block) about two common git/gh workflow pitfalls before a
+#   Bash tool call runs:
+#     (a) creating a new branch while already on a non-main/master feature
+#         branch (branch stacking)
+#     (b) running `gh pr create` on a branch that already has an open PR
+#         (duplicate PR)
+#
+# Event: PreToolUse, matcher: Bash
+#
+# Wiring snippet (settings.json):
+#   {
+#     "hooks": {
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [
+#             { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/branch-pr-discipline.sh" }
+#           ]
+#         }
+#       ]
+#     }
+#   }
+#
+# Contract:
+#   - Reads the PreToolUse hook JSON payload from stdin.
+#   - Extracts .tool_input.command (jq if available, sed fallback).
+#   - WARN-ONLY: always exits 0. Never blocks the tool call.
+#   - No dependency assumed beyond coreutils/git. jq and gh are optional,
+#     guarded by `command -v`.
+
+set -u
+
+trap 'exit 0' EXIT
+
+payload="$(cat 2>/dev/null || true)"
+[ -z "$payload" ] && exit 0
+
+# --- extract .tool_input.command --------------------------------------------
+cmd=""
+if command -v jq >/dev/null 2>&1; then
+    cmd="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+else
+    cmd="$(printf '%s' "$payload" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(\([^"\\]\|\\.\)*\)".*/\1/p' | head -n1)"
+fi
+
+[ -z "${cmd:-}" ] && exit 0
+
+# Only makes sense inside a git repo.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+[ -z "$current_branch" ] && exit 0
+
+# --- (a) branch stacking warning --------------------------------------------
+# Matches: git checkout -b <name>  /  git switch -c <name>
+if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+checkout[[:space:]]+.*-b([[:space:]]|$)' \
+    || printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+switch[[:space:]]+.*-c([[:space:]]|$)'; then
+    case "$current_branch" in
+        main|master) ;;
+        *)
+            echo "WARNING: creating a new branch from '$current_branch' (not main/master) stacks work on an unmerged branch."
+            ;;
+    esac
+fi
+
+# --- (b) duplicate PR warning ------------------------------------------------
+if printf '%s' "$cmd" | grep -Eq 'gh[[:space:]]+pr[[:space:]]+create'; then
+    if command -v gh >/dev/null 2>&1; then
+        if gh pr view --json number >/dev/null 2>&1; then
+            echo "WARNING: an open PR already exists for branch '$current_branch' — 'gh pr create' may create a duplicate."
+        fi
+    fi
+fi
+
+exit 0

--- a/.claude/hooks/dangerous-command-guard.sh
+++ b/.claude/hooks/dangerous-command-guard.sh
@@ -6,6 +6,10 @@
 
 INPUT=$(cat)
 
+# jq is required to parse tool input; fail open if unavailable (hooks are
+# guardrails, not a security boundary)
+command -v jq >/dev/null 2>&1 || exit 0
+
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 

--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# post-edit-lint.sh
+#
+# Purpose:
+#   Auto-format/lint a file immediately after Claude edits or writes it,
+#   using whatever formatter the project already declares (detected via
+#   project marker files). Fully silent on the happy path; if a formatter
+#   still reports unfixable issues after auto-fix, print a short excerpt
+#   so the model can see and address them.
+#
+# Event: PostToolUse, matcher: Edit|MultiEdit|Write
+#
+# Wiring snippet (settings.json):
+#   {
+#     "hooks": {
+#       "PostToolUse": [
+#         {
+#           "matcher": "Edit|MultiEdit|Write",
+#           "hooks": [
+#             { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit-lint.sh" }
+#           ]
+#         }
+#       ]
+#     }
+#   }
+#
+# Contract:
+#   - Reads the PostToolUse hook JSON payload from stdin.
+#   - Extracts .tool_input.file_path (jq if available, sed fallback).
+#   - Never blocks the agent: always exits 0, no matter what happens.
+#   - No dependency assumed beyond coreutils. jq/npx/ruff/gofmt/rustfmt
+#     are all optional; every invocation is guarded by `command -v`
+#     (or --no-install for npx) so absence is a silent no-op.
+#
+# Formatter detection (by project marker, first match wins):
+#   biome.json | biome.jsonc            -> npx --no-install @biomejs/biome check --write <file>   (js/ts/jsx/tsx/json)
+#   .prettierrc* | "prettier" in package.json -> npx --no-install prettier --write <file>
+#   ruff.toml | [tool.ruff] in pyproject.toml -> ruff format <file> && ruff check --fix <file>     (.py)
+#   *.go                                -> gofmt -w <file>
+#   *.rs                                -> rustfmt <file>
+
+set -u
+
+# Always succeed from the hook's perspective; never block the tool call.
+trap 'exit 0' EXIT
+
+payload="$(cat 2>/dev/null || true)"
+[ -z "$payload" ] && exit 0
+
+# --- extract .tool_input.file_path -----------------------------------------
+file_path=""
+if command -v jq >/dev/null 2>&1; then
+    file_path="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty' 2>/dev/null)"
+else
+    # Minimal fallback: pull the first "file_path":"..." value out of the JSON.
+    file_path="$(printf '%s' "$payload" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+fi
+
+[ -z "${file_path:-}" ] && exit 0
+[ -f "$file_path" ] || exit 0
+
+# --- resolve project dir ----------------------------------------------------
+project_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+# Resolve to absolute paths for a reliable prefix check.
+abs_file="$(cd "$(dirname "$file_path")" 2>/dev/null && pwd -P)/$(basename "$file_path")"
+abs_project="$(cd "$project_dir" 2>/dev/null && pwd -P)"
+
+[ -z "$abs_file" ] && exit 0
+[ -z "$abs_project" ] && exit 0
+
+case "$abs_file" in
+    "$abs_project"/*) ;;
+    *) exit 0 ;;
+esac
+
+# --- skip noisy / vendored paths --------------------------------------------
+case "$abs_file" in
+    */node_modules/*|*/dist/*|*/build/*|*/.git/*|*/vendor/*) exit 0 ;;
+esac
+
+# --- extension check ---------------------------------------------------------
+ext="${abs_file##*.}"
+case "$ext" in
+    js|jsx|ts|tsx|json|py|go|rs) ;;
+    *) exit 0 ;;
+esac
+
+# --- capture formatter output, print at most 8 lines on failure ------------
+run_and_report() {
+    # remaining args = command to run (no label argument)
+    out="$("$@" 2>&1)"
+    status=$?
+    if [ $status -ne 0 ] && [ -n "$out" ]; then
+        printf '%s\n' "$out" | head -n 8
+    fi
+    return 0
+}
+
+did_format=0
+
+# 1) Biome
+if [ -f "$project_dir/biome.json" ] || [ -f "$project_dir/biome.jsonc" ]; then
+    case "$ext" in
+        js|jsx|ts|tsx|json)
+            if command -v npx >/dev/null 2>&1; then
+                run_and_report npx --no-install @biomejs/biome check --write "$abs_file"
+                did_format=1
+            fi
+            ;;
+    esac
+fi
+
+# 2) Prettier
+if [ "$did_format" -eq 0 ]; then
+    has_prettier_marker=0
+    for f in "$project_dir"/.prettierrc "$project_dir"/.prettierrc.*; do
+        [ -f "$f" ] && has_prettier_marker=1
+    done
+    if [ -f "$project_dir/package.json" ] && grep -q '"prettier"' "$project_dir/package.json" 2>/dev/null; then
+        has_prettier_marker=1
+    fi
+    if [ "$has_prettier_marker" -eq 1 ]; then
+        case "$ext" in
+            js|jsx|ts|tsx|json)
+                if command -v npx >/dev/null 2>&1; then
+                    run_and_report npx --no-install prettier --write "$abs_file"
+                    did_format=1
+                fi
+                ;;
+        esac
+    fi
+fi
+
+# 3) Ruff
+if [ "$did_format" -eq 0 ] && [ "$ext" = "py" ]; then
+    has_ruff_marker=0
+    [ -f "$project_dir/ruff.toml" ] && has_ruff_marker=1
+    if [ -f "$project_dir/pyproject.toml" ] && grep -q '\[tool\.ruff\]' "$project_dir/pyproject.toml" 2>/dev/null; then
+        has_ruff_marker=1
+    fi
+    if [ "$has_ruff_marker" -eq 1 ] && command -v ruff >/dev/null 2>&1; then
+        run_and_report ruff format "$abs_file"
+        run_and_report ruff check --fix "$abs_file"
+        did_format=1
+    fi
+fi
+
+# 4) gofmt
+if [ "$did_format" -eq 0 ] && [ "$ext" = "go" ]; then
+    if command -v gofmt >/dev/null 2>&1; then
+        run_and_report gofmt -w "$abs_file"
+        did_format=1
+    fi
+fi
+
+# 5) rustfmt
+if [ "$did_format" -eq 0 ] && [ "$ext" = "rs" ]; then
+    if command -v rustfmt >/dev/null 2>&1; then
+        run_and_report rustfmt "$abs_file"
+        did_format=1
+    fi
+fi
+
+exit 0

--- a/.claude/hooks/post-tool-use-tracker.sh
+++ b/.claude/hooks/post-tool-use-tracker.sh
@@ -3,6 +3,10 @@
 
 INPUT=$(cat)
 
+# jq is required to parse tool input; fail open if unavailable (hooks are
+# guardrails, not a security boundary)
+command -v jq >/dev/null 2>&1 || exit 0
+
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null || true)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
@@ -16,7 +20,7 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
 # Compute relative path
 if [[ "$FILE_PATH" == "$PROJECT_DIR"* ]]; then
-    REL_PATH="${FILE_PATH#$PROJECT_DIR/}"
+    REL_PATH="${FILE_PATH#"$PROJECT_DIR"/}"
 else
     REL_PATH="$FILE_PATH"
 fi
@@ -42,7 +46,7 @@ echo "[$TIMESTAMP] [$SESSION_SHORT] $TOOL_NAME: $REL_PATH" >> "$TRACKER_FILE"
 # Release file lock if held by this session
 LOCK_FILE="$LOCK_DIR/$(echo "$REL_PATH" | tr '/' '_').lock"
 if [ -f "$LOCK_FILE" ]; then
-    LOCK_SESSION=$(cat "$LOCK_FILE" 2>/dev/null | jq -r '.session_id // empty')
+    LOCK_SESSION=$(jq -r '.session_id // empty' <"$LOCK_FILE" 2>/dev/null || true)
     if [ "$LOCK_SESSION" = "$SESSION_ID" ]; then
         rm -f "$LOCK_FILE"
     fi

--- a/.claude/hooks/pre-commit-verification.sh
+++ b/.claude/hooks/pre-commit-verification.sh
@@ -5,6 +5,10 @@
 
 INPUT=$(cat)
 
+# jq is required to parse tool input; fail open if unavailable (hooks are
+# guardrails, not a security boundary)
+command -v jq >/dev/null 2>&1 || exit 0
+
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
@@ -27,6 +31,7 @@ VERIFICATION_FILE="$STATE_DIR/commit-verified"
 # If verification was completed recently (within last 5 minutes), allow commit
 if [ -f "$VERIFICATION_FILE" ]; then
     VERIFIED_TIME=$(cat "$VERIFICATION_FILE" 2>/dev/null || echo 0)
+    [[ "$VERIFIED_TIME" =~ ^[0-9]+$ ]] || VERIFIED_TIME=0
     CURRENT_TIME=$(date +%s)
     TIME_DIFF=$((CURRENT_TIME - VERIFIED_TIME))
 

--- a/.claude/hooks/pre-push-main-blocker.sh
+++ b/.claude/hooks/pre-push-main-blocker.sh
@@ -10,6 +10,10 @@
 
 INPUT=$(cat)
 
+# jq is required to parse tool input; fail open if unavailable (hooks are
+# guardrails, not a security boundary)
+command -v jq >/dev/null 2>&1 || exit 0
+
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 

--- a/.claude/hooks/pre-tool-use-validator.sh
+++ b/.claude/hooks/pre-tool-use-validator.sh
@@ -4,6 +4,10 @@
 
 INPUT=$(cat)
 
+# jq is required to parse tool input; fail open if unavailable (hooks are
+# guardrails, not a security boundary)
+command -v jq >/dev/null 2>&1 || exit 0
+
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null || true)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
@@ -19,7 +23,7 @@ mkdir -p "$LOCK_DIR"
 
 # Get relative path for lock file naming
 if [[ "$FILE_PATH" == "$PROJECT_DIR"* ]]; then
-    REL_PATH="${FILE_PATH#$PROJECT_DIR/}"
+    REL_PATH="${FILE_PATH#"$PROJECT_DIR"/}"
 else
     REL_PATH="$FILE_PATH"
 fi
@@ -29,8 +33,9 @@ LOCK_FILE="$LOCK_DIR/$(echo "$REL_PATH" | tr '/' '_').lock"
 
 # Check for concurrent edits (swarm conflict prevention)
 if [ -f "$LOCK_FILE" ]; then
-    LOCK_SESSION=$(cat "$LOCK_FILE" 2>/dev/null | jq -r '.session_id // empty')
-    LOCK_TIME=$(cat "$LOCK_FILE" 2>/dev/null | jq -r '.timestamp // 0')
+    LOCK_SESSION=$(jq -r '.session_id // empty' <"$LOCK_FILE" 2>/dev/null || true)
+    LOCK_TIME=$(jq -r '.timestamp // 0' <"$LOCK_FILE" 2>/dev/null || echo 0)
+    [[ "$LOCK_TIME" =~ ^[0-9]+$ ]] || LOCK_TIME=0
     CURRENT_TIME=$(date +%s)
 
     # Lock expires after 120 seconds
@@ -62,7 +67,7 @@ if [[ "$REL_PATH" == *.test.ts ]] || [[ "$REL_PATH" == *.spec.ts ]] || \
     # Test files may contain mock secrets — skip detection
     :
 elif [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" ]]; then
-    CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // .tool_input.new_string // empty')
+    CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // .tool_input.new_string // empty' 2>/dev/null || true)
 
     # Check for potential secrets - multiple patterns
     SECRET_DETECTED=false

--- a/.claude/hooks/session-start-loader.sh
+++ b/.claude/hooks/session-start-loader.sh
@@ -3,6 +3,11 @@
 # Loads project context and swarm state
 
 INPUT=$(cat)
+
+# jq is required to parse tool input; fail open if unavailable (hooks are
+# guardrails, not a security boundary)
+command -v jq >/dev/null 2>&1 || exit 0
+
 SOURCE=$(echo "$INPUT" | jq -r '.source // "startup"' 2>/dev/null || echo "startup")
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
 
@@ -39,8 +44,8 @@ fi
 
 # Check for pending work from previous sessions
 if [ -f "$STATE_DIR/handoff.json" ]; then
-    HANDOFF=$(cat "$STATE_DIR/handoff.json")
-    HANDOFF_MSG=$(echo "$HANDOFF" | jq -r '.message // empty')
+    HANDOFF=$(cat "$STATE_DIR/handoff.json" 2>/dev/null || true)
+    HANDOFF_MSG=$(echo "$HANDOFF" | jq -r '.message // empty' 2>/dev/null || true)
     if [ -n "$HANDOFF_MSG" ]; then
         CONTEXT="$CONTEXT
 

--- a/.claude/hooks/stop-validator.sh
+++ b/.claude/hooks/stop-validator.sh
@@ -3,6 +3,11 @@
 # Ensures clean handoff and state sync before session ends
 
 INPUT=$(cat)
+
+# jq is required to parse tool input; fail open if unavailable (hooks are
+# guardrails, not a security boundary)
+command -v jq >/dev/null 2>&1 || exit 0
+
 STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || echo "false")
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
 
@@ -20,7 +25,7 @@ SESSION_SHORT=$(echo "$SESSION_ID" | cut -c1-8)
 if [ -d "$LOCK_DIR" ]; then
     for lock_file in "$LOCK_DIR"/*.lock; do
         [ -f "$lock_file" ] || continue
-        LOCK_SESSION=$(cat "$lock_file" 2>/dev/null | jq -r '.session_id // empty')
+        LOCK_SESSION=$(jq -r '.session_id // empty' <"$lock_file" 2>/dev/null || true)
         if [ "$LOCK_SESSION" = "$SESSION_ID" ]; then
             rm -f "$lock_file"
         fi

--- a/.claude/hooks/subagent-stop-validator.sh
+++ b/.claude/hooks/subagent-stop-validator.sh
@@ -3,7 +3,18 @@
 # Ensures subagents complete their assigned work before returning
 
 INPUT=$(cat)
-STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || echo "false")
+
+# Prefer jq for parsing; fall back to a simple grep for this trivial
+# boolean field so logging still works on a machine without jq.
+if command -v jq >/dev/null 2>&1; then
+    STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || echo "false")
+else
+    if echo "$INPUT" | grep -qE '"stop_hook_active"[[:space:]]*:[[:space:]]*true'; then
+        STOP_HOOK_ACTIVE="true"
+    else
+        STOP_HOOK_ACTIVE="false"
+    fi
+fi
 
 # Prevent infinite loops
 if [ "$STOP_HOOK_ACTIVE" = "true" ]; then

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -284,7 +284,26 @@
       "Write(~/.zshrc)",
       "Write(~/.bash_profile)",
       "Edit(~/.ssh/**)",
-      "Write(~/.ssh/**)"
+      "Write(~/.ssh/**)",
+
+      "// === Project Secrets (Read) ===",
+      "Read(**/.env)",
+      "Read(**/.env.local)",
+      "Read(**/.env.development)",
+      "Read(**/.env.production)",
+      "Read(**/secrets/**)",
+      "Read(**/*.pem)",
+      "Read(**/id_rsa*)",
+      "Read(**/credentials)",
+      "Read(**/.npmrc)",
+      "Read(~/.git-credentials)",
+      "Read(~/.config/gh/**)",
+
+      "// === Push to Default Branch ===",
+      "Bash(git push origin main:*)",
+      "Bash(git push origin master:*)",
+      "Bash(git push -u origin main:*)",
+      "Bash(git push -u origin master:*)"
     ]
   },
   "enableAllProjectMcpServers": true,
@@ -329,6 +348,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-push-main-blocker.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/branch-pr-discipline.sh",
+            "timeout": 5
           }
         ]
       }
@@ -341,6 +365,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-tool-use-tracker.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit-lint.sh",
+            "timeout": 10
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skill catalog rationalized from 67 to 14 (generic language/framework skills that duplicate model training data removed; deleted skills remain recoverable from git history)
 - `.claude/commands/` migrated to `.claude/skills/<name>/SKILL.md` (slash names unchanged); side-effecting workflows gated with `disable-model-invocation: true`
 
+### Added
+
+- `post-edit-lint` and `branch-pr-discipline` hooks (generic, fail-soft); `project-secret` and `push-to-default-branch` deny rules
+
 ### Changed
 
 - Worker agents pinned to cost-efficient model tiers with least-privilege tool allowlists
+- All hooks hardened to jq-optional fail-soft with explicit timeouts
 
 <!-- Later PRs: append new Added / Changed / Deprecated / Removed / Fixed / Security entries above this line, keeping the [3.0.0] - Unreleased section open until release. -->

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -161,6 +161,12 @@ six gated skills do not auto-fire — if your Claude Code version predates
 support for this field, the field is ignored and those skills may still be
 model-invocable, so update before relying on the gate.
 
+## Permissions
+
+v3 denies reads of `.env*`, secrets, and keys at the permission layer (`permissions.deny` in `.claude/settings.json`). Previously this was only a claim in the README backed by a warn-only hook; it is now actually enforced and cannot be overridden by an allow rule from any scope. `.env.example` stays readable — the deny rule targets files that plausibly hold real secrets, not example/template files.
+
+If your workflow legitimately needs to read a path that's now denied, don't work around it ad hoc — fork the deny rule deliberately: remove or narrow the specific `permissions.deny` line in your own `.claude/settings.json` (or `settings.local.json` for a machine-local exception), understanding that doing so re-opens the exposure the rule existed to close.
+
 ## What's next
 
 Additional v3 changes will land in subsequent updates. Entries documenting

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Pre-configured hooks that run automatically:
 - **Dangerous command guard** — warns on `rm -rf`, force push, `terraform destroy`
 - **File locking** — prevents concurrent edits in multi-agent swarms
 
+What ships enabled: format, warn, and guard hooks, all fail-soft (a missing `jq` or unparseable input skips the check rather than blocking). Secret-bearing paths and destructive commands are denied at the permission layer (`permissions.deny`), not just warned about by a hook. See [docs/hooks.md#security-model](docs/hooks.md#security-model) for what hooks can and cannot guarantee.
+
 ### MCP Servers
 
 Four servers pre-configured in `.mcp.json`:

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -14,6 +14,8 @@ Hooks run automatically at key points in Claude Code's lifecycle.
 | `post-tool-use-tracker.sh` | PostToolUse | Track file changes |
 | `stop-validator.sh` | Stop | Release file locks, cleanup session state, warn about uncommitted changes |
 | `subagent-stop-validator.sh` | SubagentStop | Log swarm worker completion |
+| `post-edit-lint.sh` | PostToolUse | Auto-format after edits; surfaces only unfixable issues |
+| `branch-pr-discipline.sh` | PreToolUse (Bash) | Warn-only branch/PR hygiene checks |
 
 **Optional examples**: Skills are discovered natively (no hook required — see [docs/skills.md](skills.md#how-skills-activate)). Teams that want deterministic, keyword-based skill activation instead can opt into [docs/examples/skill-activation-hook.sh](examples/skill-activation-hook.sh); it is dependency-free and disabled by default.
 
@@ -137,6 +139,21 @@ For PreToolUse hooks, return a permission decision:
 - Keep hooks fast (< 5 seconds timeout)
 - Test with: `echo '{}' | ./my-hook.sh`
 - Override hooks via `settings.local.json`
+
+## Security model
+
+Committed hooks are executable code. Once you trust a workspace, every hook registered in `.claude/settings.json` runs automatically, on every collaborator's machine, without a per-run confirmation. Treat hook scripts with the same scrutiny as any other code that executes on checkout — review them before trusting a repo. 2026 supply-chain research demonstrated remote code execution via malicious committed agent-config hooks; this is not theoretical.
+
+The hooks shipped in this repo are **guardrails, not a security boundary**. They are designed to **fail open**: if `jq` is missing, or the hook receives input it can't parse, the check is skipped and the tool call proceeds. This is a deliberate tradeoff for reliability over strict enforcement — do not rely on a hook to be the only thing standing between an agent and a destructive or unsafe action.
+
+HARD rules — the ones that must always hold — live in `settings.json` under `permissions.deny`. A deny entry there cannot be overridden by an allow rule from any scope (project, user, or local settings). If something absolutely must never happen, it belongs in `permissions.deny`, not in a hook.
+
+Only **exit code 2** blocks an action. Exit code 1 (or any non-zero code other than 2) is treated as a non-blocking error and does not stop the tool call — our blocking hooks either exit with code 2 or return deny-JSON (`permissionDecision: "deny"`) explicitly. If you write a hook intended to block, verify it actually exits 2 or returns deny-JSON; anything else is advisory only.
+
+**How to disable a hook:**
+
+- Remove its entry from `.claude/settings.json` (`hooks` section) to disable it for everyone who pulls that config.
+- Set `"disableAllHooks": true` in your local `settings.local.json` to disable all hooks for your own machine only.
 
 ---
 


### PR DESCRIPTION
Implements **PR6** of the modernization plan. Stacked on #13.

## Changes
- **Hard rules moved to `permissions.deny`** (deny beats allow from any scope; hooks fail open by design): project-secret reads (`.env` family, `secrets/**`, `*.pem`, `id_rsa*`, `credentials`, `.npmrc`, `~/.git-credentials`, `~/.config/gh`) + pushes to the default branch. `.env.example` deliberately stays readable. README's `.env`-protection claim is now actually enforced.
- **All 8 existing hooks hardened** (behavior-preserving, verified per-diff): jq-optional guards or grep fallbacks, quoting fixes, integer validation, zero `exit 1` signaling — blocking paths use exit 2 / deny-JSON only.
- **Two new generic hooks** (live-tested by the verifier): `post-edit-lint` (formatter auto-detection by project marker, auto-fix-then-surface ≤8 lines, silent happy path, always exit 0) and `branch-pr-discipline` (warn-only branch/PR hygiene).
- **`docs/hooks.md` Security model**: committed hooks run on every collaborator's machine (2026 supply-chain RCE research) — review before trusting; guardrails-not-boundary; only exit 2 blocks; disable instructions.

## Acceptance criteria (verified)
- `jq` parses settings; pre-existing entries byte-identical (pure append) ✅
- `bash -n` all 10 hooks; every jq use guarded; no eval of tool input; no unquoted path vars ✅
- Both new hooks live-executed: silent happy paths, capped output, exit 0 on malformed input ✅
- Adversarial verify: PASS (6/6); full invariants gate: ALL GREEN ✅

Stack: #8 ← #9 ← #10 ← #11 ← #12 ← #13 ← **this** ← PR7…

🤖 Generated with [Claude Code](https://claude.com/claude-code)