### PR TITLE
PR8: CI — machine-enforced framework invariants

### DIFF
--- a/.github/workflows/framework-invariants.yml
+++ b/.github/workflows/framework-invariants.yml
@@ -1,0 +1,19 @@
+name: framework-invariants
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  invariants:
+    name: Check framework invariants
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run invariant checks
+        run: ./scripts/check-invariants.sh

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Framework invariants checker — the PR8 CI gate, runnable locally at every PR boundary.
+# Usage:  ./check-invariants.sh              # run all checks
+#         SKIP="no-beads gating" ./check-invariants.sh   # skip named checks (pre-landing phases)
+# Exits non-zero if any non-skipped check fails.
+
+set -u
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+FAIL=0
+SKIP="${SKIP:-}"
+
+skipped() { case " $SKIP " in *" $1 "*) return 0;; *) return 1;; esac; }
+report() { # $1=check $2=status(0 pass) $3=detail
+  if skipped "$1"; then echo "SKIP  $1"; return; fi
+  if [ "$2" -eq 0 ]; then echo "PASS  $1"; else echo "FAIL  $1 — ${3:-}"; FAIL=1; fi
+}
+
+# 1. no-beads: no beads/bd references in tracked files (outside artifacts/changelog/migration)
+hits=$(git grep -Iiw -e beads -e bd -- ':!artifacts/' ':!CHANGELOG*' ':!MIGRATION*' ':!scripts/check-invariants.sh' 2>/dev/null | wc -l | tr -d ' ')
+report no-beads "$([ "$hits" = 0 ]; echo $?)" "$hits tracked reference(s): git grep -Iiw -e beads -e bd -- ':!artifacts/' ':!CHANGELOG*' ':!MIGRATION*' ':!scripts/check-invariants.sh'"
+
+# 2. no-node-deps: no Node toolchain files tracked under .claude/
+hits=$(git ls-files '.claude/**/package.json' '.claude/**/package-lock.json' '.claude/**/tsconfig.json' '.claude/**/node_modules/**' '.claude/**/*.ts' 2>/dev/null | wc -l | tr -d ' ')
+report no-node-deps "$([ "$hits" = 0 ]; echo $?)" "$hits Node file(s) tracked under .claude/"
+
+# 3. no-skill-rules: skill-rules.json must not exist (native discovery)
+hits=$(git ls-files '**/skill-rules.json' 'skill-rules.json' 2>/dev/null | wc -l | tr -d ' ')
+report no-skill-rules "$([ "$hits" = 0 ]; echo $?)" "skill-rules.json still tracked"
+
+# 4. skill-length: every SKILL.md body < 500 lines
+bad=""
+while IFS= read -r f; do
+  n=$(wc -l < "$f" | tr -d ' ')
+  [ "$n" -ge 500 ] && bad="$bad $f($n)"
+done < <(git ls-files '*SKILL.md')
+report skill-length "$([ -z "$bad" ]; echo $?)" "over 500 lines:$bad"
+
+# 5. name-eq-dir: SKILL.md frontmatter name == parent directory name
+bad=""
+while IFS= read -r f; do
+  dir=$(basename "$(dirname "$f")")
+  nm=$(awk '/^---$/{c++;next} c==1 && /^name:/{sub(/^name:[ ]*/,"");gsub(/["'"'"']/,"");print;exit}' "$f")
+  [ -n "$nm" ] && [ "$nm" != "$dir" ] && bad="$bad $f(name=$nm dir=$dir)"
+done < <(git ls-files '*SKILL.md')
+report name-eq-dir "$([ -z "$bad" ]; echo $?)" "mismatch:$bad"
+
+# 6. settings-valid: settings.json parses as JSON and declares $schema
+if command -v jq >/dev/null 2>&1; then
+  jq -e '."$schema"' .claude/settings.json >/dev/null 2>&1; rc=$?
+  report settings-valid "$rc" ".claude/settings.json fails to parse or lacks \$schema"
+elif command -v python3 >/dev/null 2>&1; then
+  python3 -m json.tool .claude/settings.json >/dev/null 2>&1; rc=$?
+  report settings-valid "$rc" ".claude/settings.json fails to parse (python3 json.tool)"
+else
+  report settings-valid 0 "(no jq or python3 — parse check skipped)"
+fi
+
+# 7. model-tiering: agents use aliases; only worker-architect may be opus
+bad=""
+while IFS= read -r f; do
+  m=$(awk '/^---$/{c++;next} c==1 && /^model:/{sub(/^model:[ ]*/,"");print;exit}' "$f")
+  case "$m" in haiku|sonnet|opus|fable|inherit|"") ;; *) bad="$bad $f(non-alias:$m)";; esac
+  if [ "$m" = "opus" ] && [ "$(basename "$f")" != "worker-architect.md" ]; then bad="$bad $f(opus)"; fi
+done < <(git ls-files '.claude/agents/*.md')
+report model-tiering "$([ -z "$bad" ]; echo $?)" "violations:$bad"
+
+# 8. no-model-drift: docs must not pair reviewer/research workers with opus
+hits=$(git grep -InE 'worker-(reviewer|research)[^a-z].*opus' -- ':!artifacts/' ':!CHANGELOG*' ':!MIGRATION*' 2>/dev/null | wc -l | tr -d ' ')
+report no-model-drift "$([ "$hits" = 0 ]; echo $?)" "$hits stale opus pairing(s)"
+
+# 9. gating: side-effecting skills must carry disable-model-invocation: true
+bad=""
+for s in builder swarm-execute swarm-plan swarm-review swarm-research code-check; do
+  f=".claude/skills/$s/SKILL.md"
+  if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+    grep -q '^disable-model-invocation: true' "$f" || bad="$bad $s"
+  fi
+done
+report gating "$([ -z "$bad" ]; echo $?)" "ungated side-effecting skill(s):$bad"
+
+# 10. no-private-ids: no private-reference identifiers in tracked files
+hits=$({ git grep -IniwE 'argo|42gen' -- ':!scripts/check-invariants.sh' 2>/dev/null | grep -viE 'cargo|argocd'; git grep -InE 'ENG-[0-9]+|/Users/[a-z]+' -- ':!scratchpad/' ':!scripts/check-invariants.sh' 2>/dev/null; } | wc -l | tr -d ' ')
+report no-private-ids "$([ "$hits" = 0 ]; echo $?)" "$hits private identifier hit(s)"
+
+# 11. desc-budget: total always-on description chars under ~6000 (~1.5k tokens proxy for the 1% listing budget)
+total=$(git ls-files '.claude/skills/*/SKILL.md' '.claude/skills/*/*/SKILL.md' | while IFS= read -r f; do
+  awk '/^---$/{c++;next} c==1 && /^description:/{sub(/^description:[ ]*/,"");print}' "$f"
+done | wc -c | tr -d ' ')
+report desc-budget "$([ "${total:-0}" -lt 6000 ]; echo $?)" "description total ${total} chars (budget proxy 6000)"
+
+# 12. worktrees-ignored: swarm worktrees path must be gitignored
+grep -q '^\.claude/worktrees/' .gitignore; report worktrees-ignored $? ".gitignore lacks .claude/worktrees/"
+
+# 13. hooks-valid: every shipped hook must be syntactically valid bash
+bad=""
+while IFS= read -r f; do
+  bash -n "$f" 2>/dev/null || bad="$bad $f"
+done < <(git ls-files '.claude/hooks/*.sh')
+report hooks-valid "$([ -z "$bad" ]; echo $?)" "bash -n failed:$bad"
+
+echo ""
+[ "$FAIL" -eq 0 ] && echo "ALL CHECKS GREEN" || echo "INVARIANT FAILURES PRESENT"
+exit "$FAIL"


### PR DESCRIPTION
Implements **PR8** of the modernization plan. Stacked on #15.

## Why
The framework had no CI — every acceptance criterion in PR1–PR7 was a manual grep. This makes the invariants durable: a future contributor cannot re-introduce beads, node deps under `.claude/`, an oversized skill, an ungated side-effecting skill, or model drift without CI going red.

## Changes
- **`scripts/check-invariants.sh`** — 13 checks (~0.5s): no-beads · no-node-deps · no-skill-rules · skill-length<500 · name==dir · settings schema-valid · model-tiering (only architect=opus, aliases only) · no-model-drift · side-effect gating · no-private-ids · description budget · worktrees-ignored · hooks bash-valid. Skippable per-check via `SKIP=` for staged adoption; self-excluded from its own pattern checks; `jq`→`python3` fallback.
- **`.github/workflows/framework-invariants.yml`** — runs it on every `pull_request` (fires for stacked PRs too) and pushes to `main`; `contents: read` least privilege; checkout@v4 shallow-clone-safe (index-only git operations).

## Sequencing note
The plan said "introduce early" — this is the earliest green point: checks 1–9 only hold after PR2–PR7 land. The script itself has gated every PR boundary locally since PR1.

## Verification
- Adversarial CI-environment review: PASS (0 critical; both suggestions applied: `${3:-}` hardening + jq-less fallback) ✅
- Self-test with all changes staged: 13/13 GREEN ✅

Stack: #8 ← #9 ← #10 ← #11 ← #12 ← #13 ← #14 ← #15 ← **this** ← PR9

🤖 Generated with [Claude Code](https://claude.com/claude-code)