### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #23)

### DIFF
--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Design systems and record architecture decisions as ADRs — a user-invoked Principal Architect workflow.
-argument-hint: [design-topic]
+argument-hint: "[design-topic]"
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/builder/SKILL.md
+++ b/.claude/skills/builder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: builder
 description: Translate plans into working, tested code through implementation, debugging, and refactoring — a user-invoked Builder workflow.
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/code-check/SKILL.md
+++ b/.claude/skills/code-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-check
 description: Audit a codebase holistically for SOLID, DRY, and consistency violations — a user-invoked Codebase Auditor workflow.
-argument-hint: [scope: all | path/to/dir | glob]
+argument-hint: "[scope: all | path/to/dir | glob]"
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/qa-engineer/SKILL.md
+++ b/.claude/skills/qa-engineer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qa-engineer
 description: Define test strategy and verify quality against WCAG and testing-pyramid criteria — a user-invoked QA Engineer workflow.
-argument-hint: [component-to-test]
+argument-hint: "[component-to-test]"
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/security-auditor/SKILL.md
+++ b/.claude/skills/security-auditor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: security-auditor
 description: Assess vulnerabilities and audit for security compliance using OWASP and STRIDE methodology — a user-invoked Security Auditor workflow.
-argument-hint: [scope-or-component]
+argument-hint: "[scope-or-component]"
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/swarm-execute/SKILL.md
+++ b/.claude/skills/swarm-execute/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: swarm-execute
 description: Execute an implementation plan with parallel worker swarms, quality gates, and native task tracking — a user-invoked Execution Orchestrator workflow.
-argument-hint: [plan-artifact-or-task-id]
+argument-hint: "[plan-artifact-or-task-id]"
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/swarm-plan/SKILL.md
+++ b/.claude/skills/swarm-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: swarm-plan
 description: Decompose a feature into an actionable implementation plan using parallel worker-explorer swarms — a user-invoked Planning Orchestrator workflow.
-argument-hint: [feature-or-task-description]
+argument-hint: "[feature-or-task-description]"
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/swarm-research/SKILL.md
+++ b/.claude/skills/swarm-research/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: swarm-research
 description: Coordinate parallel research workers to investigate a topic deeply and synthesize citation-backed findings — a user-invoked Research Orchestrator workflow.
-argument-hint: [research-topic-or-question]
+argument-hint: "[research-topic-or-question]"
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/swarm-review/SKILL.md
+++ b/.claude/skills/swarm-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: swarm-review
 description: Run an adversarial, multi-perspective code review with root-cause analysis and security focus — a user-invoked Adversarial Reviewer workflow.
-argument-hint: [branch-name-or-pr-number]
+argument-hint: "[branch-name-or-pr-number]"
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/ui-ux-designer/SKILL.md
+++ b/.claude/skills/ui-ux-designer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ui-ux-designer
 description: Design interfaces and validate accessibility against WCAG 2.1 with DevTools-backed checks — a user-invoked UI/UX Designer workflow.
-argument-hint: [component-or-flow]
+argument-hint: "[component-or-flow]"
 disable-model-invocation: true
 ---
 

--- a/.claude/templates/skill.template.md
+++ b/.claude/templates/skill.template.md
@@ -1,7 +1,7 @@
 ---
 name: [skill-name]
 description: [Clear description of what this skill does and when Claude should use it. Include trigger phrases like "Use when..." to help with skill invocation.]
-argument-hint: [optional-arg-description]
+argument-hint: "[optional-arg-description]"
 disable-model-invocation: false
 ---
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -10,7 +10,7 @@ Commands are just skills invoked by their slash name. Create `.claude/skills/my-
 ---
 name: my-command
 description: What this command does
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 disable-model-invocation: true
 ---
 ```


### PR DESCRIPTION
Closes #23.

## Summary

Purely mechanical single-character transform to 12 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (12)

- `.claude/skills/builder/SKILL.md`
- `.claude/skills/architect/SKILL.md`
- `.claude/skills/qa-engineer/SKILL.md`
- `.claude/skills/ui-ux-designer/SKILL.md`
- `.claude/skills/security-auditor/SKILL.md`
- `docs/customization.md`
- `.claude/templates/skill.template.md`
- `.claude/skills/code-check/SKILL.md`
- `.claude/skills/swarm-review/SKILL.md`
- `.claude/skills/swarm-plan/SKILL.md`
- `.claude/skills/swarm-execute/SKILL.md`
- `.claude/skills/swarm-research/SKILL.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
