### PR TITLE
Policy: trunk-based development — independently mergeable units to main

### DIFF
--- a/.claude/rules/core-directives.md
+++ b/.claude/rules/core-directives.md
@@ -8,7 +8,7 @@ These directives translate the Core Principles into concrete, day-to-day operati
 
 ## Constraints
 
-- Always branch from `main` — never commit directly to the main branch
+- Trunk-based development: `main` is the only long-lived branch. Branch short-lived units off `main`, and every PR targets `main` and must be **independently mergeable** — no stacked PR chains, and no integration branches that accumulate work for a later bulk merge. Sequence dependent work by merge order (land the prerequisite to `main`, then branch the dependent unit from `main`), never by basing one unit's branch on another's. Never commit directly to `main`.
 - Verify artifacts exist before proceeding to the next phase in the planning flow
 - Consult `tech-strategy.md` for all technology choices — do not deviate without explicit instruction
 - Ship It: work is not complete until pushed to remote — mechanical protocol lives in AGENTS.md "Landing the Plane" (canonical detail-level home)

--- a/.claude/skills/swarm-execute/SKILL.md
+++ b/.claude/skills/swarm-execute/SKILL.md
@@ -71,7 +71,7 @@ Run quality gates per `code-quality.md` — all must pass. No exceptions.
 
 ## Coordination Protocol
 
-1. **Orchestrator** decomposes work into tasks via `TaskCreate`, with acceptance criteria and `blockedBy` dependencies
+1. **Orchestrator** decomposes work into tasks via `TaskCreate`, with acceptance criteria and `blockedBy` dependencies — each unit shaped to merge to `main` independently (trunk-based, per core-directives)
 2. **Orchestrator** claims a task on behalf of a worker: `TaskUpdate` (status: in_progress)
 3. **Workers** execute their assigned task following AGENTS.md "Landing the Plane" workflow — workers do NOT touch the task list themselves
 4. **Workers** report completion (and any follow-up work discovered) back to the orchestrator
@@ -88,6 +88,8 @@ Workers do not have direct access to the native task list — the orchestrator o
 3. **Pushes** the feature branch to remote (mandatory — see Core Directives "Constraints" for the Ship It rule)
 4. **Cleans up** the worker's worktree
 5. **Marks the task completed** via `TaskUpdate`, and files any follow-up work the worker reported via `TaskCreate`
+
+The feature branch itself PRs to `main` directly when its unit is complete — trunk-based. A unit that depends on unmerged work waits for that work to land on `main` and then branches from `main`; never open a PR whose base is another unit's branch.
 
 ## Checkpointing
 

--- a/.claude/skills/swarm-plan/SKILL.md
+++ b/.claude/skills/swarm-plan/SKILL.md
@@ -25,7 +25,7 @@ Decompose features into actionable plans using parallel exploration swarms.
 1. **Explore** — Launch 3-6 worker-explorer agents to research existing patterns, dependencies, constraints, and prior art
 2. **Classify** — Determine decision reversibility (Two-Way Door vs One-Way Door)
 3. **Document** — Create appropriate artifacts based on scope
-4. **Decompose** — Break into right-sized tasks: roughly 200-400 changed LOC or 15-45 minutes of focused work each — review effectiveness collapses beyond ~400 LOC (SmartBear/Cisco)
+4. **Decompose** — Break into right-sized tasks: roughly 200-400 changed LOC or 15-45 minutes of focused work each — review effectiveness collapses beyond ~400 LOC (SmartBear/Cisco). Shape every unit to be independently mergeable to `main` (trunk-based, per core-directives): dependencies resolve by merge order, not by stacking branches
 5. **Track** — Record tasks in the native task list for implementation tracking
 
 ## Decision Framework
@@ -125,6 +125,7 @@ Link dependencies with `TaskUpdate` (addBlockedBy): Task 2 gets Task 1 added to 
 - ALWAYS store artifacts in `./artifacts/`
 - ALWAYS record implementation tasks with acceptance criteria before declaring planning complete
 - ALWAYS validate arguments before using in commands
+- NO plans that require stacked PR chains or integration branches — every planned unit merges to `main` on its own; a dependent unit branches from `main` after its prerequisite lands
 
 ## Output
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,4 @@ Three failure cases and how the orchestrator recovers from each:
 - Never stop before pushing — that leaves work stranded locally
 - Never say "ready to push when you are" — push it yourself
 - If push fails, resolve and retry until it succeeds
+- PRs target `main` — trunk-based: a dependent unit waits for its prerequisite to merge to `main` and branches from there, rather than stacking on the prerequisite's branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Trunk-based development is now the stated branching policy (core-directives Constraints, CLAUDE.md Workflow, AGENTS.md landing rules, swarm-plan/swarm-execute orchestration guidance): every PR targets `main` and must be independently mergeable; stacked PR chains and integration branches are disallowed — dependent work sequences by merge order on `main`
 - `agent.template.md` rewritten to the shipped agent shape: `maxTurns` is documented as required (CI `agent-maxturns`), least-privilege `tools:` allowlists replace the old advice against them, `isolation`/`skills` preload guidance added, and the `.claude-plugin/plugin.json` registration step is included; `docs/customization.md`'s worker example gains the same fields — an agent filled in from either now passes CI (smoke-tested)
 - `skill.template.md` defaults to the library frontmatter shape (command-style fields commented out) and states the CI constraints (`desc-style`, `name-eq-dir`, `desc-budget`, `skill-length`) explicitly; `hook.template.sh` opens with the canonical jq fail-open guard
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Defined in `.claude/rules/tech-strategy.md` — auto-loaded for every session.
 
 ## Workflow
 
-**Branching**: Always branch from `main`. Never commit directly to `main`.
+**Branching**: Trunk-based — short-lived branches off `main`, every PR independently mergeable back to `main` (no stacked chains, no integration branches). Never commit directly to `main`.
 
 **Planning flow**: PR-FAQ → PRD → ADR → Design Spec → Plan → Implementation Tasks — ceremony scales with scope (see `core-directives.md` Rule 6): skip phases a change genuinely doesn't need.
 


### PR DESCRIPTION
Encodes the owner-directed branching policy: **trunk-based development**. `main` is the only long-lived branch; every PR targets `main` and must be independently mergeable; stacked PR chains and integration branches are disallowed. Dependent work sequences by merge order — land the prerequisite, then branch the dependent unit from `main`.

Where it's stated (one sentence each, at the surfaces future sessions actually read):

- `.claude/rules/core-directives.md` — Constraints (the always-loaded home of the rule)
- `CLAUDE.md` — Workflow › Branching line
- `AGENTS.md` — Landing the Plane › Mode B critical rules
- `.claude/skills/swarm-plan/SKILL.md` — Decompose step + a NO-constraint (plans must not require stacking)
- `.claude/skills/swarm-execute/SKILL.md` — Coordination Protocol + completion flow (feature branches PR to `main` directly)
- CHANGELOG entry

**Independently mergeable by construction**: branched from current `main`, touches only regions the in-flight portfolio stack (#30/#31) does not — merges cleanly in either order. All invariant checks green.

Note: the currently in-flight #30/#31 predate this policy and finish under the old cascade; everything after them follows this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
