### PR TITLE
Design: stack packs & tailor v2 — exemplar packs, LLM adaptation

### DIFF
--- a/artifacts/adr_stack_packs.md
+++ b/artifacts/adr_stack_packs.md
@@ -1,0 +1,79 @@
+# ADR: Stack Packs & Tailor v2 — Exemplar Packs, LLM Adaptation
+
+**Status**: Proposed · 2026-07-23 · Evidence: `research_stack_packs.md`
+
+## Context
+
+The v4 strategy's T4 tier: stack-specific value is *generated into the adopter's repo*, never shipped as live
+skills here. Owner direction: KISS, DRY, SOLID, education-first — packs are exemplar material, not machinery.
+Constraints from research: plugins cannot carry template payloads; adopter listing budget favors one skill per
+pack; tech-strategy.md / code-quality.md / the pre-commit hook are the single sources a pack must not restate.
+
+## Decision 1 — Exemplar over template
+
+A pack is a set of **concrete, working files for the golden-path stack** — real `pnpm test`, real
+`uv lock` — with zero placeholder machinery. `/tailor` is the adaptation engine: it reads the exemplar plus its
+detection fingerprint and rewrites names/versions/commands to the adopter's reality inside the proposal.
+
+*Why*: the 2026 ecosystem converged here ("examples are concrete, not abstract"; Spec Kit; shadcn's open-code);
+jinja-class templating has a documented drift-and-tooling tax (cruft) and kills GitHub legibility. An exemplar
+is simultaneously the documentation, the education, and the template — DRY at the artifact level. Rule of
+Three: no parameter until a real third variation demands one.
+
+## Decision 2 — Pack anatomy (three files, no more)
+
+```
+.claude/templates/stack-packs/<stack>/
+  README.md             ~30 lines: what this pack is, why these choices (one paragraph, pointing at
+                        tech-strategy.md for the choice table), how /tailor adapts it, how to adapt by hand.
+                        Header carries one dated line ("Exemplar current as of 2026-07").
+  golden-path.skill.md  The ONE skill /tailor renders into the adopter repo: the stack's daily loop as
+                        directives — canonical commands (test/lint/typecheck/build), lockfile discipline,
+                        where gates run (pre-commit hook + CI). <100 lines, ungated shape, third-person
+                        description with "Use when", clean six-field frontmatter. Triggers scoped to daily
+                        build/test/run tasks — never upgrade (dependency-upgrade), landing (land-the-plane),
+                        or review config (review-steering).
+  ci-gates.yml          Thin Actions job snippet running the four gates with the stack's commands; references
+                        upstream actions, vendors nothing.
+```
+
+*Why*: converged minimal set (entry doc + few fragments + zero vendored internals); one rendered skill per pack
+per first-party precedent and adopter listing-budget etiquette; anything further waits for a demonstrated need.
+
+**DRY lines (hard)**: the pack *operationalizes* — it never reproduces the tech-strategy table (it links it),
+never redefines the quality gates (it runs them), never restates hook detection (it aligns with it).
+
+## Decision 3 — Delivery: in-repo, installer-carried, free
+
+Packs live at `.claude/templates/stack-packs/<stack>/`. The installer already copies `templates/` recursively —
+zero new machinery; GitHub renders packs as browsable education; free onramp by construction. No plugin
+packaging: mechanically impossible for template payloads and adds overhead for zero function.
+
+## Decision 4 — Tailor v2: one new phase
+
+`Propose: Instantiate`, after `Propose: Steer`: scan `stack-packs/` (open/closed — a new pack is a new
+directory, zero engine change); for each **detected** stack with a pack, adapt the exemplar to the fingerprint
+(every substitution evidence-cited; defaults flagged when no signal exists — the dogfooded no-vibes discipline);
+rendered files join the existing proposal and apply checklist. New mode `instantiate` in the argument hint.
+Never render for an undetected stack; never write outside the proposal.
+
+## SOLID, in one breath
+
+One pack = one stack (SRP). New packs extend without touching the engine (O/C). Every pack satisfies the same
+three-file convention, so tailor treats any pack identically (LSP). Packs expose only what tailor needs — a
+directory matching the convention (ISP). Tailor depends on the convention, not on any pack's contents (DIP).
+
+## Rejected
+
+- **Placeholder/template engine** ({{vars}}, variable tables, render rules) — drift tax, legibility tax,
+  redundant beneath an LLM adapter.
+- **Plugin delivery** — no template payload type exists; indirection via skill-copies-files adds steps, not value.
+- **Per-domain skill fan-out** (scaffold-router pattern) — adopter listing budget; one skill + references wins.
+- **Pack-owned choice tables** — tech-strategy.md is the single source of truth for choices.
+
+## Consequences
+
+Packs are cheap to author (write the exemplar you'd want to read), cheap to maintain (update like any doc, one
+dated line), and testable via the smoke-test convention (adapt against the fixture; rendered skill must pass
+desc-style/spec-portability shape). Python/Go packs are pure additions. The bet's risk — LLM adaptation fidelity
+— is bounded by tailor's evidence-citation constraint and covered by an instantiate eval case.

--- a/artifacts/plan_stack_packs.md
+++ b/artifacts/plan_stack_packs.md
@@ -1,0 +1,42 @@
+# Plan: Stack Packs & Tailor v2
+
+> Executes `adr_stack_packs.md`. Trunk-based: each unit is an independently mergeable PR to `main`;
+> U2/U3 branch from `main` after U1 lands. 2026-07-23.
+
+## U1 — Engine + convention + TypeScript pack (one PR)
+
+The convention, the engine, and the first pack land together — an engine without a pack is untestable, a pack
+without an engine is inert. Scope:
+
+1. `.claude/templates/stack-packs/README.md` (≤40 lines): the three-file convention, exemplar-not-template
+   principle, DRY lines (link tech-strategy/code-quality/hook — never restate), dated-header convention,
+   adopter-listing-budget note, how `/tailor` discovers packs (directory scan).
+2. `typescript/` pack per ADR Decision 2 — concrete golden-path values (pnpm · Vite · Biome · Vitest ·
+   React 19 · Node LTS), README with the one-paragraph why + adapt notes, golden-path skill exemplar,
+   ci-gates snippet.
+3. Tailor v2: `Propose: Instantiate` phase + `instantiate` mode + `references/packs.md` (≤30 lines: scan,
+   adapt-with-evidence, default-flagging, undetected-stack refusal); +1 eval case
+   (`mixed-repo-instantiates-only-detected-packs`).
+4. docs/customization.md: short "Stack packs" note under Artifact Templates; CHANGELOG entry.
+
+**AC**: all invariant checks green; smoke test per PR #25 convention — adapt the TS pack against
+`scratchpad/tailor-fixture` by hand, stage the rendered skill at a throwaway path, prove desc-style +
+spec-portability + name-eq-dir pass, revert, evidence in the PR body; elegance test — every pack file legible
+raw on GitHub, zero placeholder tokens; grep proves the pack reproduces no tech-strategy table rows.
+
+## U2 — Python pack · U3 — Go pack (one PR each, after U1)
+
+Pure additions under `stack-packs/`: same three files, golden-path values from tech-strategy (Python 3.13 · uv ·
+Ruff · Litestar · msgspec · pytest/mypy; Go 1.25 · golangci-lint · sqlc/pgx per table). No engine changes —
+that's the ADR's open/closed test. Same ACs (smoke test uses the fixture for Python; Go gets a 3-file fixture
+added to scratchpad in-branch). Sequence U2 → U3 by merge order (shared CHANGELOG anchor).
+
+## Out of scope (Rule of Three / YAGNI)
+
+Rust/Swift/Kotlin packs (add on demand); pack versioning beyond the dated line; any placeholder machinery;
+plugin packaging; pack content beyond the three files.
+
+## Risks
+
+LLM adaptation fidelity → bounded by evidence-citation constraint + instantiate eval (ADR Consequences).
+Golden-path drift (tooling moves) → the dated line + normal doc maintenance; no sync machinery by design.

--- a/artifacts/research_stack_packs.md
+++ b/artifacts/research_stack_packs.md
@@ -1,0 +1,55 @@
+# Research: Stack Packs & Tailor v2
+
+> 3-worker swarm (internal seams · scaffold prior art · skills-era delivery), 2026-07-23.
+> Feeds `adr_stack_packs.md`. Raw worker reports: session records (gitignored scratchpad).
+
+## Findings
+
+1. **The ecosystem abandoned templating machinery.** Every 2026-era agent artifact ships concrete files, not
+   placeholders: Anthropic's authoring checklist says "Examples are concrete, not abstract" and reserves rigid
+   parameterization for fragile operations only; GitHub Spec Kit ships plain markdown templates agents fill in;
+   awesome-copilot ships plain instruction files; shadcn/ui made "open code you copy and own" a pillar *because*
+   LLMs read and adapt it. The agent-assisted-scaffolding pattern names the replacement mechanism outright:
+   repository-aware generation instead of parameter filling. (HIGH — primary sources.)
+2. **Heavy templating has a documented failure lineage.** Cookiecutter's jinja projects drift so badly a
+   dedicated tool (cruft) exists just to diff generated repos against templates; unknown placeholders fail
+   silently; Copier shifts the cost into maintainer-authored migrations. The no-engine systems (GitHub template
+   repos, nix flake templates, create-vite's real-directory variants) are the legible, low-maintenance end of
+   the spectrum. (HIGH.)
+3. **Minimal pack content converges across ecosystems**: identity/date metadata + a few composable fragments +
+   one entry-point doc + zero vendored tool internals — reference upstream mechanisms so staleness is upstream's
+   problem (Renovate presets, VS Code extensions.json, devcontainer features, Actions starter workflows). (MEDIUM-HIGH.)
+4. **Delivery is mechanically decided, not stylistic**: Claude Code plugins have *no template payload type* —
+   only skills/agents/hooks/MCP/LSP/etc. are live-loaded, and a plugin CLAUDE.md is explicitly not project
+   context. One-shot-rendered files can only come from a directory the installer copies (or a skill that
+   Write-copies bundled files — indirection with no benefit here). In-repo `templates/` dir wins; plugin
+   wrapping adds overhead for zero function. (HIGH — plugins-reference.)
+5. **One rendered skill per pack has first-party precedent**: official best practice models a multi-domain
+   capability as ONE skill + `reference/` files (zero cost until read) versus per-domain skills (each costs
+   listing budget unconditionally); a ~20-skill community scaffold router is the cautionary counter-example.
+   Adopter listing budget is the constraint that matters — pack-rendered skills live there, not in this repo's CI. (HIGH.)
+6. **Education principles are specific**: Diátaxis — ruthlessly minimize explanation inside task material, state
+   the why once near the top; README-driven — one load-bearing entry doc; Rule of Three — never parameterize a
+   variation seen once; one default with an escape hatch, not an options menu. (HIGH.)
+7. **Internal seams (this repo)**: tailor v1's Detect/Assess/Propose contract and tier precedence extend cleanly;
+   `.claude/templates/` is recursively installer-copied (a new `stack-packs/` subdir reaches adopters with zero
+   installer changes, scrub-safe); repo template convention is bracketed-placeholder-or-concrete — no handlebars
+   anywhere; tech-strategy.md tables are the single source for *choices*, `pre-commit-verification.sh` already
+   detects stacks, and quality gates are defined once in code-quality.md — a pack must operationalize, never
+   restate, all three. Rendered skills must clear desc-style/spec-portability shape by construction, and their
+   triggers must stay clear of `dependency-upgrade`, `land-the-plane`, `review-steering`. (HIGH — file-anchored.)
+
+## What elegance looks like (synthesis)
+
+Concrete runnable files, GitHub-legible with zero tooling; one README per pack read first by human and agent
+alike; smallest working set, layered by composition; the why stated once, then the artifact; the LLM treated as
+a literate engineer that substitutes names/paths/versions itself; no drift machinery because there is nothing
+to drift — an exemplar is read once and adapted.
+
+## Confidence & gaps
+
+Concrete-over-template convergence, plugin payload constraint, listing-budget precedent: HIGH (primary sources,
+quotes verified by workers 2026-07-23). Minimal-content convergence: MEDIUM-HIGH (one Actions-starter claim
+unverified). No direct evidence found on nx/moon exclusion policy (nearest: moon's `--minimal` flag). Sources
+indexed in the worker reports; key anchors: platform.claude.com skill best-practices, code.claude.com
+plugins-reference, anthropics/skills, ui.shadcn.com/docs, cruft.github.io, diataxis.fr, containers.dev.


### PR DESCRIPTION
Research + ADR + plan for the F workstream, per the design-first direction. **No implementation in this PR** — it locks the design for review before any pack is built.

**The design in three sentences**: A pack is three concrete, GitHub-legible files per stack (README with the why + adapt notes, one golden-path skill exemplar, a thin CI-gates snippet) — real values, zero placeholder machinery, because /tailor's LLM is the adaptation engine (it rewrites the exemplar to the detected stack, every substitution evidence-cited). Delivery is the already-installer-copied `.claude/templates/stack-packs/` directory — mechanically forced, since plugins have no template payload type, and free by construction. Tailor v2 adds exactly one phase (Propose: Instantiate) that discovers packs by directory scan, so new packs are pure additions (open/closed).

**Why exemplar-over-template**: the 2026 ecosystem converged on concrete artifacts (Anthropic's "examples are concrete, not abstract", Spec Kit, awesome-copilot, shadcn's open-code-for-AI pillar), while jinja-class templating carries a documented drift-and-tooling tax (the Cookiecutter→cruft lineage). Full evidence with confidence labels in `artifacts/research_stack_packs.md`.

**Plan**: U1 = convention + engine + TypeScript pack (one PR, smoke-tested against the tailor fixture); U2 Python, U3 Go — pure additions, each its own PR from main after U1. Rust/Swift/Kotlin wait for demand (Rule of Three).

DRY lines are hard constraints in the ADR: packs operationalize tech-strategy/code-quality/hook content, never restate it; the rendered skill's triggers stay clear of dependency-upgrade / land-the-plane / review-steering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)