### PR TITLE
U1: stack-pack convention, tailor v2 instantiate phase, TypeScript pack

### DIFF
--- a/.claude/skills/tailor/SKILL.md
+++ b/.claude/skills/tailor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tailor
 description: Detects the project's stack from manifests and proposes tailored framework configuration — filled tech-strategy golden paths, REVIEW.md/CLAUDE.md review steering, and a prune list of unused framework pieces — as a reviewable plan, never silent writes.
-argument-hint: "[all | detect | fill | steer | prune]"
+argument-hint: "[all | detect | fill | steer | prune | instantiate]"
 disable-model-invocation: true
 metadata:
   category: encoded-preference
@@ -48,6 +48,12 @@ For each **detected** language, draft a ready-to-paste golden-path table using t
 
 Invoke the `review-steering` skill's workflow to draft `REVIEW.md` and verify `CLAUDE.md`'s review-context section is current. Include both the drafted `REVIEW.md` content and any `CLAUDE.md` delta in the proposal — do not write either file directly.
 
+## Propose: Instantiate
+
+For each pack in `.claude/templates/stack-packs/` whose stack Detect actually found, adapt the exemplar to the fingerprint — substitute package manager, test runner, framework, and version strings for the detected reality, evidence-cited per substitution; flag a default when no signal exists rather than inventing one. See `references/packs.md` for the discovery and adaptation rules this phase follows.
+
+Render `golden-path.skill.md` at its adopter-repo target path (e.g. `.claude/skills/typescript-golden-path/SKILL.md`) and `ci-gates.yml` as a ready-to-paste block for the adopter's own CI workflow — never for a stack Detect did not find.
+
 ## Propose: Prune
 
 List framework pieces irrelevant to the detected stack: unused golden-path language sections, hook checks that can't fire for this stack, skills the adopter may want to gate. Each entry needs a one-line rationale and the exact file/line — no bulk "remove unused stuff" claims.
@@ -58,24 +64,27 @@ List framework pieces irrelevant to the detected stack: unused golden-path langu
 
 1. Stack-fingerprint table (Detect)
 2. Per-file proposed blocks, ready to paste (Fill, Steer, Prune)
-3. Conflict flags (Assess)
-4. An apply checklist — one checkbox per file to change
+3. Rendered pack files (Instantiate), each with its adopter-repo target path and the evidence-cited substitutions applied
+4. Conflict flags (Assess)
+5. An apply checklist — one checkbox per file to change
 
 Application happens only after the user approves the plan — either by manually pasting the approved blocks, or by re-invoking `/tailor` with the approved checklist.
 
 ## Modes
 
-- `all` (default) — Detect + Assess, then all three Propose phases; full proposal
+- `all` (default) — Detect + Assess, then all four Propose phases; full proposal
 - `detect` — Detect only; fingerprint table
 - `fill` — Detect + Assess + Propose: Fill
 - `steer` — Detect + Assess + Propose: Steer
 - `prune` — Detect + Assess + Propose: Prune
+- `instantiate` — Detect + Assess + Propose: Instantiate
 
 ## Constraints
 
 - NO silent writes to `.claude/rules/`, `.claude/settings.json`, `CLAUDE.md`, or any other tracked config file — proposal only, always
 - NO deleting or overwriting user-customized content — flag the conflict instead
 - NO stack claims without cited evidence — every fingerprint row names its source file
+- NO rendering a pack for a stack Detect did not find — instantiation is scoped strictly to detected stacks, never speculative
 - ALWAYS re-run after major stack changes (new language, package-manager migration, framework swap) — a stale proposal is worse than none
 - ALWAYS require explicit user approval before anything in the proposal is applied — the constraint most tempting to skip under time pressure
 

--- a/.claude/skills/tailor/evals/evals.json
+++ b/.claude/skills/tailor/evals/evals.json
@@ -68,6 +68,20 @@
           "tailor is a near-miss here: it assumes the framework is already present and customizes it, it does not perform the initial install"
         ]
       }
+    },
+    {
+      "id": "mixed-repo-instantiates-only-detected-packs",
+      "category": "positive",
+      "prompt": "This repo has package.json/pnpm-lock.yaml/vitest.config.ts AND pyproject.toml/uv.lock with [tool.ruff] configured, but no go.mod, Cargo.toml, or Package.swift anywhere — run /tailor instantiate.",
+      "expected": {
+        "assertions": [
+          "renders the TypeScript pack's golden-path.skill.md, adapted with the detected pnpm/vitest evidence, at its adopter-repo target path .claude/skills/typescript-golden-path/SKILL.md",
+          "renders the Python pack's golden-path.skill.md, adapted with the detected uv/ruff evidence, at its own adopter-repo target path, independently of the TypeScript rendering",
+          "does not render a Go, Rust, or Swift pack — Detect found no go.mod, Cargo.toml, or Package.swift, so no pack for those stacks is instantiated, invented, or hallucinated",
+          "cites the specific evidence file behind every substitution in each rendered file (e.g. pnpm-lock.yaml, uv.lock) rather than asserting an adaptation with no cited source",
+          "adds both rendered files to the scratchpad/tailor-proposal.md plan rather than writing directly into .claude/skills/"
+        ]
+      }
     }
   ]
 }

--- a/.claude/skills/tailor/references/packs.md
+++ b/.claude/skills/tailor/references/packs.md
@@ -1,0 +1,18 @@
+# Pack Discovery & Adaptation
+
+Mechanical rules for the Propose: Instantiate phase — the pack-side counterpart to `detection.md` (that file maps signals to golden-path rows; this one maps a detected stack to a rendered skill).
+
+## Discovery
+
+Scan `.claude/templates/stack-packs/` for subdirectories. Each subdirectory is one pack, named after its stack (`typescript`, `python`, ...). A pack qualifies for instantiation only if Detect already found that stack's manifest/lockfile signal — the directory scan proves a pack exists, not that its stack applies here. Adding a pack is a new directory under `stack-packs/`; no code path in this skill changes.
+
+## Adaptation Rules
+
+- Substitute only values the fingerprint table evidences — a `yarn.lock` swaps every `pnpm` for `yarn`, cited to that file; no `yarn.lock` means no substitution.
+- No signal for a given value (package manager, test runner, framework, version)? Flag it in the proposal as "no signal, exemplar default kept" — never guess.
+- Preserve the exemplar's structure and line budget. Adapting is substitution, not a rewrite: don't add sections, don't pad, don't restate what the pack already links elsewhere.
+- Never render a pack whose stack Detect did not find, even if the pack directory exists.
+
+## Listing-Budget Warning
+
+Every rendered `golden-path.skill.md` becomes a live, always-loaded skill in the adopter's own repo the moment it's committed. Flag this in the proposal so the user weighs it the same way they'd weigh adding any other skill — instantiation isn't free just because the content was pre-written.

--- a/.claude/templates/stack-packs/README.md
+++ b/.claude/templates/stack-packs/README.md
@@ -1,0 +1,32 @@
+# Stack Packs
+
+`/tailor`'s source material for its `Propose: Instantiate` phase — one directory per supported stack, each a set of concrete, working files for that stack's golden path.
+
+## Convention: Three Files, No More
+
+```
+.claude/templates/stack-packs/<stack>/
+  README.md             What this pack is, why these choices, how /tailor adapts it,
+                         how to adapt by hand. Opens with one dated line:
+                         "Exemplar current as of YYYY-MM".
+  golden-path.skill.md  The ONE skill /tailor renders into the adopter's repo: the
+                         stack's daily loop as directives.
+  ci-gates.yml           Thin CI job snippet running the same gates with the stack's
+                         own commands.
+```
+
+## Exemplar, Not Template
+
+A pack is concrete, working files for the golden-path stack — real commands, real values, zero double-brace placeholder machinery. `/tailor`'s LLM is the adaptation engine: it reads a pack plus the repo's detection fingerprint and substitutes into the proposal. See `artifacts/adr_stack_packs.md` (Decision 1) for the full rationale.
+
+## DRY Lines (Hard)
+
+A pack never reproduces `.claude/rules/tech-strategy.md`'s choice table, never redefines `.claude/rules/code-quality.md`'s gates, and never restates `.claude/hooks/pre-commit-verification.sh`'s stack detection — every pack links each of the three and operationalizes what they already define.
+
+## Listing Budget
+
+`golden-path.skill.md` is the only skill a pack renders into an adopter's repo — every rendered skill costs that adopter's always-loaded listing budget, so a pack ships exactly one, shaped to pass this repo's own `desc-style`/`spec-portability` invariants.
+
+## Discovery
+
+`/tailor` finds packs by scanning this directory — a new pack is a new subdirectory here; adding one changes zero lines of `/tailor` itself.

--- a/.claude/templates/stack-packs/typescript/README.md
+++ b/.claude/templates/stack-packs/typescript/README.md
@@ -1,0 +1,17 @@
+# TypeScript / JavaScript Golden-Path Pack
+
+Exemplar current as of 2026-07.
+
+Concrete, working files for this framework's TypeScript/JavaScript golden path: pnpm, Vite, Biome, Vitest, React 19, Node LTS. Two files: `golden-path.skill.md` (the skill `/tailor` renders into an adopter's repo) and `ci-gates.yml` (the matching CI job).
+
+## Why These Choices
+
+The golden-path values baked into this pack aren't this pack's decision — they're pulled straight from the TypeScript/JavaScript row set in `.claude/rules/tech-strategy.md`, this framework's single source of truth for technology choices. Change the stack there and this pack drifts from it until someone updates the pack to match; the pack never carries its own copy of that table.
+
+## How `/tailor` Adapts It
+
+`Propose: Instantiate` (`.claude/skills/tailor/SKILL.md`) reads this pack only once Detect's fingerprint shows a TypeScript/JavaScript manifest. It then substitutes the exemplar's package manager, test runner, and framework names for whatever the fingerprint evidences — e.g. a `yarn.lock` swaps every `pnpm` for `yarn`, cited to that lockfile — and flags anything with no signal as a kept default instead of guessing.
+
+## How to Adapt by Hand
+
+Edit `golden-path.skill.md` and `ci-gates.yml` directly, then rename the containing directory to match the skill's `name:` field before committing it as `.claude/skills/<name>/SKILL.md` — this framework's `name-eq-dir` check enforces the match.

--- a/.claude/templates/stack-packs/typescript/ci-gates.yml
+++ b/.claude/templates/stack-packs/typescript/ci-gates.yml
@@ -1,0 +1,22 @@
+# Merge this job into your repo's own GitHub Actions workflow (e.g.
+# .github/workflows/ci.yml) under its `jobs:` key — not meant to run standalone.
+#
+# Tags verified upstream via `git ls-remote --tags <repo>` (2026-07):
+#   actions/checkout v7.0.1 · pnpm/action-setup v6.0.9 · actions/setup-node v7.0.0
+# pnpm's own version comes from this repo's package.json "packageManager" field —
+# action-setup reads it automatically, so no version is pinned here.
+
+gates:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v7.0.1
+    - uses: pnpm/action-setup@v6.0.9
+    - uses: actions/setup-node@v7.0.0
+      with:
+        node-version: lts/*
+        cache: pnpm
+    - run: pnpm install --frozen-lockfile
+    - run: pnpm test        # vitest run
+    - run: pnpm lint        # biome check .
+    - run: pnpm typecheck   # tsc --noEmit
+    - run: pnpm build       # vite build

--- a/.claude/templates/stack-packs/typescript/golden-path.skill.md
+++ b/.claude/templates/stack-packs/typescript/golden-path.skill.md
@@ -1,0 +1,41 @@
+---
+name: typescript-golden-path
+description: Runs this project's TypeScript/JavaScript golden-path commands for day-to-day development — typecheck, lint, test, and build via pnpm. Use when building, testing, linting, or type-checking this project, adding an npm script, or asking how to run it locally.
+metadata:
+  category: encoded-preference
+---
+
+<!-- Rendered by /tailor from .claude/templates/stack-packs/typescript/golden-path.skill.md.
+     This file's containing directory must match `name:` above — commit it at
+     .claude/skills/typescript-golden-path/SKILL.md, not anywhere else. -->
+
+# TypeScript Golden Path
+
+This project's daily loop runs on pnpm, Vite, Biome, and Vitest — golden-path choices recorded in `.claude/rules/tech-strategy.md`, not decided here.
+
+## The Daily Loop
+
+- While editing: keep typecheck and lint in a tight loop — run them after every meaningful change, not just before a commit.
+- Before every commit: `pnpm test`.
+- Before shipping: `pnpm build` — a passing test suite doesn't guarantee a passing build.
+
+## The Four Commands
+
+| Command | Runs |
+|---------|------|
+| `pnpm test` | `vitest run` |
+| `pnpm lint` | `biome check .` |
+| `pnpm typecheck` | `tsc --noEmit` |
+| `pnpm build` | `vite build` |
+
+## Lockfile Discipline
+
+Regenerate `pnpm-lock.yaml` with `pnpm install` — never hand-edit it. Commit it in the same commit as the `package.json` change that produced it, every time.
+
+## Gates Wiring
+
+`.claude/hooks/pre-commit-verification.sh` auto-detects this stack from `package.json` and reminds you to run these commands before a commit lands. CI runs the identical four gates — see this pack's `ci-gates.yml`.
+
+## Related Skills
+
+Not this skill's job: `dependency-upgrade` (bumping a package), `land-the-plane` (shipping the finished work), `review-steering` (configuring automated code review).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Add entries under Breaking / Added / Changed / Deprecated / Removed / Fixed / Security. scripts/release.sh stamps this section with a version and date at release time. -->
 
+### Added
+
+- Stack packs (`.claude/templates/stack-packs/`): concrete, working exemplar files per stack — one `README.md`, one `golden-path.skill.md`, one `ci-gates.yml`, zero placeholder tokens — that operationalize `tech-strategy.md`'s choices, `code-quality.md`'s gates, and `pre-commit-verification.sh`'s detection instead of restating them (see `artifacts/adr_stack_packs.md`). TypeScript/JavaScript ships first (pnpm/Vite/Biome/Vitest/React 19/Node LTS); Python and Go follow as pure per-stack additions under the same three-file convention
+- `/tailor` v2: new `Propose: Instantiate` phase and `instantiate` mode — for each pack whose stack Detect actually found, adapts the exemplar to the fingerprint (evidence-cited substitutions, flagged defaults, never an undetected stack) and joins the rendered files to the existing proposal; `references/packs.md` documents the discovery/adaptation rules and the adopter listing-budget cost of every rendered skill. New eval case `mixed-repo-instantiates-only-detected-packs`
+- `docs/customization.md` "Stack Packs" section under Artifact Templates, pointing adopters at `/tailor instantiate` and the pack convention doc
+
 ## [4.0.0] - 2026-07-23
 
 ### Added

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -72,6 +72,14 @@ The framework intentionally ships no stack-specific frontend rule (React, Vue, e
 
 Skills that produce planning artifacts bundle their templates inside the owning skill's `resources/` directory, so each skill stays self-contained (e.g. `.claude/skills/architecture/designing-systems/resources/adr.template.md`, `.claude/skills/product/planning-artifacts/resources/prd.template.md`). Three artifact types have no owning library skill; starter templates for those live in `.claude/templates/artifacts/`: `plan`, `design_spec`, `security_audit`. (The postmortem template moved into the `postmortem` skill's `resources/` when that skill was added.) Output naming for all artifact types is defined in CLAUDE.md's artifact table.
 
+## Stack Packs
+
+`.claude/templates/stack-packs/<stack>/` holds concrete, working exemplar files for one stack's golden path: a README, the one skill `/tailor` renders into your repo (`golden-path.skill.md`), and a CI job snippet (`ci-gates.yml`) — zero placeholder tokens, real commands.
+
+Run `/tailor instantiate` once your stack is detectable; it adapts the exemplar to your repo's actual package manager, test runner, and framework, every substitution evidence-cited, and never renders a stack it didn't detect.
+
+TypeScript/JavaScript ships today; Python and Go are planned. See `.claude/templates/stack-packs/README.md` for the full convention.
+
 ## Adding a Hook
 
 See [hooks.md](hooks.md) for the full guide.


### PR DESCRIPTION
First build unit of the approved stack-packs design (`artifacts/adr_stack_packs.md`, PR #35 — the two PRs are independent and merge in any order).

**What ships** (9 files, all budgets met):
- `.claude/templates/stack-packs/README.md` — the three-file convention: exemplar-not-template, hard DRY links (tech-strategy / code-quality / hook — linked, never restated), dated headers, listing-budget note, directory-scan discovery.
- `typescript/` pack — concrete exemplars, zero placeholders (`grep '{{'` clean): a 41-line golden-path skill (daily loop → four commands → lockfile discipline → gates wiring → Related-Skills boundary line keeping clear of dependency-upgrade/land-the-plane/review-steering) and a 22-line CI snippet whose action pins were **ls-remote-verified** (`checkout@v7.0.1`, `pnpm/action-setup@v6.0.9`, `setup-node@v7.0.0`; pnpm version omitted deliberately — confirmed optional at the pinned tag when package.json declares `packageManager`).
- Tailor v2: `Propose: Instantiate` phase + `instantiate` mode + `references/packs.md` (adapt only fingerprint-evidenced values, flag defaults, never render undetected stacks) + a new eval case (`mixed-repo-instantiates-only-detected-packs`).
- docs/customization.md stack-packs note + CHANGELOG entry.

**Smoke test** (PR #25 convention): the rendered skill was staged at `.claude/skills/typescript-golden-path/SKILL.md` and all 21 invariant checks passed with it in place (desc-budget 4322/6000), then reverted clean. Full gate tail in the worker report; re-verified green on this branch after landing.

**Follow-ups tracked**: U2 Python and U3 Go as pure-addition PRs after this merges; docs/skills.md's "Generated by tailor *(roadmap)*" tier line graduates when all three packs exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)