### PR TITLE
U2: Python stack pack

### DIFF
--- a/.claude/templates/stack-packs/python/README.md
+++ b/.claude/templates/stack-packs/python/README.md
@@ -1,0 +1,17 @@
+# Python Golden-Path Pack
+
+Exemplar current as of 2026-07.
+
+Concrete, working files for this framework's Python golden path: Python 3.13+, uv, Ruff, Litestar, msgspec, asyncpg — plus pytest and mypy, the gate-suite tools `.claude/hooks/pre-commit-verification.sh` detects via `pyproject.toml`. Two files: `golden-path.skill.md` (the skill `/tailor` renders into an adopter's repo) and `ci-gates.yml` (the matching CI job).
+
+## Why These Choices
+
+The golden-path values baked into this pack aren't this pack's decision — they're pulled straight from the Python row set in `.claude/rules/tech-strategy.md`, this framework's single source of truth for technology choices. Change the stack there and this pack drifts from it until someone updates the pack to match; the pack never carries its own copy of that table.
+
+## How `/tailor` Adapts It
+
+`Propose: Instantiate` (`.claude/skills/tailor/SKILL.md`) reads this pack only once Detect's fingerprint shows a Python manifest. It then substitutes the exemplar's package manager, linter, and framework names for whatever the fingerprint evidences — e.g. a `poetry.lock` swaps every `uv` command for its poetry equivalent, cited to that lockfile, or a `pyproject.toml` with no `[tool.ruff]` table but a flake8 config present swaps Ruff's commands for flake8's, evidence-cited — and flags anything with no signal as a kept default instead of guessing.
+
+## How to Adapt by Hand
+
+Edit `golden-path.skill.md` and `ci-gates.yml` directly, then rename the containing directory to match the skill's `name:` field before committing it as `.claude/skills/<name>/SKILL.md` — this framework's `name-eq-dir` check enforces the match.

--- a/.claude/templates/stack-packs/python/ci-gates.yml
+++ b/.claude/templates/stack-packs/python/ci-gates.yml
@@ -1,0 +1,21 @@
+# Merge this job into your repo's own GitHub Actions workflow (e.g.
+# .github/workflows/ci.yml) under its `jobs:` key — not meant to run standalone.
+#
+# Tags verified upstream via `git ls-remote --tags <repo>` (2026-07):
+#   actions/checkout v7.0.1 · astral-sh/setup-uv v9.0.0
+# No python-version input is set: astral-sh/setup-uv reads `requires-python` from
+# pyproject.toml and provisions a matching interpreter automatically — see its
+# README FAQ "Do I still need actions/setup-python alongside setup-uv?"
+
+gates:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v7.0.1
+    - uses: astral-sh/setup-uv@v9.0.0
+      with:
+        enable-cache: true
+    - run: uv sync --locked
+    - run: uv run pytest
+    - run: uv run ruff check .
+    - run: uv run ruff format --check .
+    - run: uv run mypy .

--- a/.claude/templates/stack-packs/python/golden-path.skill.md
+++ b/.claude/templates/stack-packs/python/golden-path.skill.md
@@ -1,0 +1,40 @@
+---
+name: python-golden-path
+description: Runs this project's Python golden-path commands for day-to-day development — lint, format, typecheck, and test via uv. Use when building, testing, linting, or type-checking this project, adding a uv script, or asking how to run it locally.
+metadata:
+  category: encoded-preference
+---
+
+<!-- Rendered by /tailor from .claude/templates/stack-packs/python/golden-path.skill.md.
+     This file's containing directory must match `name:` above — commit it at
+     .claude/skills/python-golden-path/SKILL.md, not anywhere else. -->
+
+# Python Golden Path
+
+This project's daily loop runs on uv, Ruff, pytest, and mypy — golden-path choices recorded in `.claude/rules/tech-strategy.md`, not decided here.
+
+## The Daily Loop
+
+- While editing: keep `ruff check` and `mypy` in a tight loop — run them after every meaningful change, not just before a commit.
+- Before every commit: `uv run pytest`.
+
+## The Four Commands
+
+| Command | Gate |
+|---------|------|
+| `uv run pytest` | Test suite |
+| `uv run ruff check .` | Lint |
+| `uv run ruff format --check .` | Format check |
+| `uv run mypy .` | Type check |
+
+## Lockfile Discipline
+
+Regenerate `uv.lock` with `uv lock` (`uv sync` regenerates it implicitly too) — never hand-edit it. Commit it in the same commit as the `pyproject.toml` change that produced it, every time.
+
+## Gates Wiring
+
+`.claude/hooks/pre-commit-verification.sh` auto-detects this stack from `pyproject.toml` and reminds you to run these commands before a commit lands. CI runs the identical four gates — see this pack's `ci-gates.yml`.
+
+## Related Skills
+
+Not this skill's job: `dependency-upgrade` (bumping a package), `land-the-plane` (shipping the finished work), `review-steering` (configuring automated code review).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stack packs (`.claude/templates/stack-packs/`): concrete, working exemplar files per stack — one `README.md`, one `golden-path.skill.md`, one `ci-gates.yml`, zero placeholder tokens — that operationalize `tech-strategy.md`'s choices, `code-quality.md`'s gates, and `pre-commit-verification.sh`'s detection instead of restating them (see `artifacts/adr_stack_packs.md`). TypeScript/JavaScript ships first (pnpm/Vite/Biome/Vitest/React 19/Node LTS); Python and Go follow as pure per-stack additions under the same three-file convention
 - `/tailor` v2: new `Propose: Instantiate` phase and `instantiate` mode — for each pack whose stack Detect actually found, adapts the exemplar to the fingerprint (evidence-cited substitutions, flagged defaults, never an undetected stack) and joins the rendered files to the existing proposal; `references/packs.md` documents the discovery/adaptation rules and the adopter listing-budget cost of every rendered skill. New eval case `mixed-repo-instantiates-only-detected-packs`
 - `docs/customization.md` "Stack Packs" section under Artifact Templates, pointing adopters at `/tailor instantiate` and the pack convention doc
+- Python stack pack (`.claude/templates/stack-packs/python/`): the second stack under the three-file convention — Python 3.13+, uv, Ruff, Litestar, msgspec, asyncpg golden path with the pytest/mypy gate suite `pre-commit-verification.sh` detects, plus a matching `ci-gates.yml`
 
 ## [4.0.0] - 2026-07-23
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -78,7 +78,7 @@ Skills that produce planning artifacts bundle their templates inside the owning 
 
 Run `/tailor instantiate` once your stack is detectable; it adapts the exemplar to your repo's actual package manager, test runner, and framework, every substitution evidence-cited, and never renders a stack it didn't detect.
 
-TypeScript/JavaScript ships today; Python and Go are planned. See `.claude/templates/stack-packs/README.md` for the full convention.
+TypeScript/JavaScript and Python ship today; Go is planned. See `.claude/templates/stack-packs/README.md` for the full convention.
 
 ## Adding a Hook
 


### PR DESCRIPTION
Second pack unit per `artifacts/plan_stack_packs.md` — a **pure addition**: three files under `.claude/templates/stack-packs/python/`, one CHANGELOG line, one availability-phrase update in docs/customization.md. **Zero engine changes** (`git diff --stat -- .claude/skills/tailor/` is empty) — the ADR's open/closed claim, demonstrated.

- Golden-path values from tech-strategy's Python table (linked, not reproduced): uv · Ruff · pytest · mypy · Litestar/msgspec/asyncpg. Commands verified against `pre-commit-verification.sh`'s actual Python detection.
- CI snippet pins **ls-remote-verified** 2026-07-23 (`checkout@v7.0.1`, `astral-sh/setup-uv@v9.0.0`); `python-version` deliberately omitted (setup-uv's pinned-tag README: uv honors `requires-python` — same don't-duplicate-the-manifest pattern as U1's pnpm decision); `uv sync --locked` chosen over `--frozen` for lockfile-staleness erroring, per uv docs.
- Smoke test: rendered skill staged at `.claude/skills/python-golden-path/SKILL.md`, all 21 checks green (desc-budget 4304/6000 with it staged), reverted clean. `grep '{{'` clean; sibling-length discipline vs the TS pack (17/40/21 lines vs 17/41/22).

U3 (Go) follows after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
